### PR TITLE
disable deprecation warnings [on linux]

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -34,6 +34,9 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 
+# Disable deprecation warnings to handle app_indicator_new deprecation
+target_compile_options(${PLUGIN_NAME} PRIVATE -Wno-deprecated-declarations)
+
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.
 pkg_check_modules(GTKMM REQUIRED IMPORTED_TARGET gtkmm-3.0)


### PR DESCRIPTION
On Ubuntu 25.04, the multipass GUI cannot build due to an error in this plugin that calls a deprecated function

```
src/client/gui/linux/flutter/ephemeral/.plugin_symlinks/tray_menu/linux/tray_menu_plugin.cc:114:23: error: 'app_indicator_new' is deprecated [-Werror,-Wdeprecated-declarations]
Building Linux application...                                           
Build process failed
```

This pull request introduces a minor update to the `linux/CMakeLists.txt` file to suppress deprecation warnings for the `app_indicator_new` function during compilation. The GUI builds and runs on Ubuntu 25.04 with no issues after these changes. Building on Windows 11 Pro does not result in this error (probably because this appears to be a linux-only plugin)

Build configuration changes:

* [`linux/CMakeLists.txt`](diffhunk://#diff-25b4e52755fc75324470232b071995ac62664f1532efcf33ce81cdc49b8c64f5R37-R39): Added the `-Wno-deprecated-declarations` compile option to disable deprecation warnings for `app_indicator_new`.


**Additional comment**

This deprecation is a sign that this plugin should have a more thorough review to update it to the latest flutter plugin best practices. It has been a couple of years since the development of this plugin, so it may also be worth researching similar flutter plugins for tray icons and to see if a better plugin in the Flutter ecosystem exists at this point to handle tray icons across operating systems for Flutter desktop.